### PR TITLE
Update build define for ruby2.5.1.

### DIFF
--- a/config/projects/td-agent3.rb
+++ b/config/projects/td-agent3.rb
@@ -19,7 +19,7 @@ build_iteration 0
 # creates required build directories
 dependency "preparation"
 
-override :ruby, :version => '2.4.4'
+override :ruby, :version => '2.5.1'
 override :zlib, :version => '1.2.11'
 override :jemalloc, :version => '4.5.0'
 override :rubygems, :version => '2.6.14'

--- a/config/software/nokogiri.rb
+++ b/config/software/nokogiri.rb
@@ -1,0 +1,84 @@
+# Copyright 2012-2017, Chef Software Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "nokogiri"
+
+license "MIT"
+license_file "https://raw.githubusercontent.com/sparklemotion/nokogiri/master/LICENSE.md"
+# We install only nokogiri from rubygems here.
+skip_transitive_dependency_licensing true
+
+dependency "ruby"
+
+using_prebuilt_ruby = windows? && (project.overrides[:ruby].nil? || project.overrides[:ruby][:version] == "ruby-windows")
+unless using_prebuilt_ruby
+  dependency "libxml2"
+  dependency "libxslt"
+  dependency "liblzma"
+  dependency "zlib"
+end
+
+dependency "rubygems"
+
+#
+# NOTE: As of nokogiri 1.6.4 it will superficially 'work' to remove most
+# of the nonsense in this file and simply gem install nokogiri on most
+# platforms.  This is because nokogiri has improved its packaging so that
+# all of the dynamic libraries are 'statically' compiled into nokogiri.so
+# with -lz -llzma -lxslt -lxml2, etc.  What will happen in that case is
+# that the nokogiri build system will pull zlib, lzma, etc out of the
+# system and link it inside of nokogiri.so and ship it as one big
+# dynamic library.  This will essentially defeat one aspect of our
+# health_check system so that we will be shipping an embedded zlib inside
+# of nokogiri.so that we do not track and will have a high likelihood that
+# if there are security errata that we ship exploitable code without
+# knowing it.  For all other purposes, the built executable will work,
+# however, so it is likely that someone will 'discover' that 'everything
+# works' and remove all the junk in this file.  That will, however, have
+# unintended side effects.  We do not have a mechanism to inspect the
+# nokogiri.so and determine that it is shipping with an embedded zlib that
+# does not match the one that we ship in /opt/chef/embedded/lib, so there
+# will be nothing that alerts or fails on this.
+#
+# TL;DR: do not remove --use-system-libraries even if everything appears to
+# be green after you do.
+#
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  gem_command = [ "install nokogiri --no-ri --no-rdoc" ]
+  gem_command << "--version '#{version}'" unless version.nil?
+
+  # windows uses the 'fat' precompiled binaries'
+  unless using_prebuilt_ruby
+    # Tell nokogiri to use the system libraries instead of compiling its own
+    env["NOKOGIRI_USE_SYSTEM_LIBRARIES"] = "true"
+
+    gem_command += [
+      "--",
+      "--use-system-libraries",
+      "--with-xml2-lib=#{install_dir}/embedded/lib",
+      "--with-xml2-include=#{install_dir}/embedded/include/libxml2",
+      "--with-xslt-lib=#{install_dir}/embedded/lib",
+      "--with-xslt-include=#{install_dir}/embedded/include/libxslt",
+      "--without-iconv",
+      "--with-zlib-dir=#{install_dir}/embedded",
+    ]
+  end
+
+  gem gem_command.join(" "), env: env
+
+  delete "#{install_dir}/embedded/lib/ruby/gems/2.1.0/gems/mini_portile2-2.0.0/test"
+end


### PR DESCRIPTION
### Abstract

While building td-agent-3.2.0 for ruby2.5.1, occur load error.
So, skip document install for nokogiri.

### Problem

- While building td-agent-3.2.0 for ruby2.5.1, occur load error.

```
      [Builder: nokogiri] I | 2018-06-27T08:48:12+00:00 | gem `install nokogiri -- --use-system-libraries --with-xml2-lib=/opt/td-agent/embedded/lib --with-xml2-include=/opt/td-agent/embedded/include/libxml2 --with-xslt-lib=/opt/td-agent/embedded/lib --with-xslt-include=/opt/td-agent/embedded/include/libxslt --without-iconv --with-zlib-dir=/opt/td-agent/embedded': 11.5725s
      [Builder: nokogiri] I | 2018-06-27T08:48:12+00:00 | Build nokogiri: 11.5732s
The following shell command exited with status 1:

    $ CFLAGS=-I/opt/td-agent/embedded/include -O2 CPPFLAGS=-I/opt/td-agent/embedded/include -O2 CXXFLAGS=-I/opt/td-agent/embedded/include -O2 LDFLAGS=-Wl,-rpath,/opt/td-agent/embedded/lib -L/opt/td-agent/embedded/lib LD_RUN_PATH=/opt/td-agent/embedded/lib NOKOGIRI_USE_SYSTEM_LIBRARIES=true OMNIBUS_INSTALL_DIR=/opt/td-agent PATH=/opt/td-agent/bin:/opt/td-agent/embedded/bin:/usr/local/lib/ruby/gems/2.5.0/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/vagrant/.local/bin:/home/vagrant/bin PKG_CONFIG_PATH=/opt/td-agent/embedded/lib/pkgconfig /opt/td-agent/embedded/bin/gem install nokogiri -- --use-system-libraries --with-xml2-lib=/opt/td-agent/embedded/lib --with-xml2-include=/opt/td-agent/embedded/include/libxml2 --with-xslt-lib=/opt/td-agent/embedded/lib --with-xslt-include=/opt/td-agent/embedded/include/libxslt --without-iconv --with-zlib-dir=/opt/td-agent/embedded

Output:

    Successfully installed mini_portile2-2.3.0
Building native extensions with: '--use-system-libraries --with-xml2-lib=/opt/td-agent/embedded/lib --with-xml2-include=/opt/td-agent/embedded/include/libxml2 --with-xslt-lib=/opt/td-agent/embedded/lib --with-xslt-include=/opt/td-agent/embedded/include/libxslt --without-iconv --with-zlib-dir=/opt/td-agent/embedded'
This could take a while...
Successfully installed nokogiri-1.8.3

Error:

    /opt/td-agent/embedded/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- ripper (LoadError)
        from /opt/td-agent/embedded/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /opt/td-agent/embedded/lib/ruby/2.5.0/rdoc/parser/ruby.rb:143:in `<top (required)>'
        from /opt/td-agent/embedded/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /opt/td-agent/embedded/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /opt/td-agent/embedded/lib/ruby/2.5.0/rdoc/parser.rb:277:in `<top (required)>'
        from /opt/td-agent/embedded/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /opt/td-agent/embedded/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /opt/td-agent/embedded/lib/ruby/2.5.0/rdoc/options.rb:622:in `block in parse'
        from /opt/td-agent/embedded/lib/ruby/2.5.0/optparse.rb:1062:in `initialize'
        from /opt/td-agent/embedded/lib/ruby/2.5.0/rdoc/options.rb:586:in `new'
        from /opt/td-agent/embedded/lib/ruby/2.5.0/rdoc/options.rb:586:in `parse'
        from /opt/td-agent/embedded/lib/ruby/2.5.0/rdoc/rubygems_hook.rb:171:in `block in generate'
        from /opt/td-agent/embedded/lib/ruby/2.5.0/rdoc/rubygems_hook.rb:168:in `chdir'
        from /opt/td-agent/embedded/lib/ruby/2.5.0/rdoc/rubygems_hook.rb:168:in `generate'
        from /opt/td-agent/embedded/lib/ruby/2.5.0/rdoc/rubygems_hook.rb:56:in `block in generation_hook'
        from /opt/td-agent/embedded/lib/ruby/2.5.0/rdoc/rubygems_hook.rb:55:in `each'
        from /opt/td-agent/embedded/lib/ruby/2.5.0/rdoc/rubygems_hook.rb:55:in `generation_hook'
        from /opt/td-agent/embedded/lib/ruby/site_ruby/2.5.0/rubygems/request_set.rb:189:in `block in install'
        from /opt/td-agent/embedded/lib/ruby/site_ruby/2.5.0/rubygems/request_set.rb:188:in `each'
        from /opt/td-agent/embedded/lib/ruby/site_ruby/2.5.0/rubygems/request_set.rb:188:in `install'
        from /opt/td-agent/embedded/lib/ruby/site_ruby/2.5.0/rubygems/commands/install_command.rb:205:in `install_gem'
        from /opt/td-agent/embedded/lib/ruby/site_ruby/2.5.0/rubygems/commands/install_command.rb:255:in `block in install_gems'
        from /opt/td-agent/embedded/lib/ruby/site_ruby/2.5.0/rubygems/commands/install_command.rb:251:in `each'
        from /opt/td-agent/embedded/lib/ruby/site_ruby/2.5.0/rubygems/commands/install_command.rb:251:in `install_gems'
        from /opt/td-agent/embedded/lib/ruby/site_ruby/2.5.0/rubygems/commands/install_command.rb:158:in `execute'
        from /opt/td-agent/embedded/lib/ruby/site_ruby/2.5.0/rubygems/command.rb:310:in `invoke_with_build_args'
        from /opt/td-agent/embedded/lib/ruby/site_ruby/2.5.0/rubygems/command_manager.rb:169:in `process_args'
        from /opt/td-agent/embedded/lib/ruby/site_ruby/2.5.0/rubygems/command_manager.rb:139:in `run'
        from /opt/td-agent/embedded/lib/ruby/site_ruby/2.5.0/rubygems/gem_runner.rb:55:in `run'
        from /opt/td-agent/embedded/bin/gem:21:in `<main>'


/home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/util.rb:139:in `rescue in shellout!'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/util.rb:134:in `shellout!'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/builder.rb:868:in `shellout!'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/builder.rb:334:in `block in gem'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/builder.rb:1058:in `instance_eval'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/builder.rb:1058:in `run'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/builder.rb:886:in `block (3 levels) in execute'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/builder.rb:908:in `with_retries'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/builder.rb:885:in `block (2 levels) in execute'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/instrumentation.rb:23:in `measure'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/builder.rb:884:in `block in execute'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/builder.rb:959:in `with_clean_env'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/builder.rb:883:in `execute'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/builder.rb:775:in `block (2 levels) in build'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/builder.rb:774:in `each'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/builder.rb:774:in `block in build'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/instrumentation.rb:23:in `measure'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/builder.rb:773:in `build'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/software.rb:1211:in `execute_build'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/software.rb:1094:in `build_me'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/project.rb:1077:in `block (2 levels) in build'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/project.rb:1076:in `each'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/project.rb:1076:in `block in build'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/licensing.rb:62:in `block in create_incrementally'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/licensing.rb:57:in `tap'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/licensing.rb:57:in `create_incrementally'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/project.rb:1075:in `build'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/cli.rb:89:in `build'
  /usr/local/lib/ruby/gems/2.5.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
  /usr/local/lib/ruby/gems/2.5.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
  /usr/local/lib/ruby/gems/2.5.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/cli/base.rb:33:in `dispatch'
  /usr/local/lib/ruby/gems/2.5.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/lib/omnibus/cli.rb:42:in `execute!'
  /home/vagrant/.bundle/ruby/2.5.0/omnibus-7e9c9a6a71c1/bin/omnibus:16:in `<top (required)>'
  bin/omnibus:29:in `load'
  bin/omnibus:29:in `<main>'
```

### Reason

While building td-agent-3.2.0 for ruby2.5.1, fail loading ripper.

### Fix detail

I can't debug detail, but for building td-agent build, nokogiri document is not needed.
So, add `--no-ri --no-rdoc` option inspect install nokogori from below define.

- https://github.com/chef/omnibus-software/blob/e37552bae32c2502253a07a8722c1f3d825b8d06/config/software/nokogiri.rb
